### PR TITLE
Improve the turbolinks life cycle feedback

### DIFF
--- a/app/assets/javascripts/app.coffee
+++ b/app/assets/javascripts/app.coffee
@@ -1,17 +1,27 @@
 # Base class for a JavaScript framework for the entire application.
-class @Application
 
-  @setup: =>
-    @currentPage = try
-      pageClassName = $("body[data-page-class]").data().pageClass
-      eval("new #{pageClassName}View()")
-    catch
-      new Application.View()
+# https://github.com/turbolinks/turbolinks/#detecting-when-a-preview-is-visible
+TurbolinksCachePreview =
+  isON: -> document.documentElement.hasAttribute("data-turbolinks-preview")
+  getPrefix: -> if @isON() then "[CACHE] " else ""
+
+Logger =
+  LEVEL: "debug"
+  treatMessage: (msg) -> "#{TurbolinksCachePreview.getPrefix()}#{msg}"
+  perform: (msg) -> console[@LEVEL] @treatMessage(msg)
+
+ViewFinder =
+  getClassName: -> $("body[data-page-class]").data().pageClass
+  getViewName: -> "#{@getClassName()}View"
+  getCurrent: -> window[@getViewName()] || Application.View
+  find: -> new (@getCurrent())()
+
+class @Application
+  @setup: ->
+    @currentPage = ViewFinder.find()
     @currentPage.setup()
 
-
-  @teardown: =>
-    @currentPage.teardown()
+  @teardown: -> @currentPage.teardown()
 
   # Base class for a JavaScript page view. Subclass this to add custom behaviour for a
   #   a specific page.
@@ -19,18 +29,20 @@ class @Application
   #   Important! Subclasses MUST define setup() and teardown() and call super() within
   #     both of those functions.
   class @View
+    constructor: ->
+      @logger = Logger
 
     # # Set up global widgets here.
     # # Example:
     # $(".lightbox").lightbox()
     setup: ->
-      console.debug("Application.View.setup()")
+      @logger.perform("Application.View.setup()")
 
     # # Tear down global widgets here.
     # # Example:
     # $(".lightbox").lightbox().delete()
     teardown: ->
-      console.debug("Application.View.teardown")
+      @logger.perform("Application.View.teardown()")
 
 
 # Add listeners to implement the above code when Turbolinks has updated the page.

--- a/app/assets/javascripts/app.coffee
+++ b/app/assets/javascripts/app.coffee
@@ -46,6 +46,8 @@ class @Application
 
 
 # Add listeners to implement the above code when Turbolinks has updated the page.
-document.addEventListener 'turbolinks:load',          Application.setup, {once: true}
-document.addEventListener 'turbolinks:render',        Application.setup
-document.addEventListener 'turbolinks:before-render', Application.teardown
+# NOTE: I removed document.addEventListener('turbolinks:load', Application.setup, {once: true})
+# because the "once" event listener option, ins't supported by all browsers. See: http://caniuse.com/#search=once
+document.addEventListener "DOMContentLoaded",         Application.setup
+document.addEventListener "turbolinks:render",        Application.setup
+document.addEventListener "turbolinks:before-render", Application.teardown

--- a/app/assets/javascripts/views/home/show.coffee
+++ b/app/assets/javascripts/views/home/show.coffee
@@ -1,19 +1,28 @@
 class @HomeShowView extends Application.View
+  constructor: ->
+    super() # Call super to set the @logger
+    @$form = $("form.input_form")
 
   setup: ->
-    super()
-    console.debug("HomeShowView.setup()")
+    @logger.perform("  HomeShowView.setup()")
 
-    $("form.input_form").on "submit", (e) ->
+    @$form.on "submit", (e) ->
       e.preventDefault()
       $input      = $(this).find("input[type='text']")
       $submit     = $("input[type='submit']")
       $outputList = $("ol.output_list")
       value       = $input.val()
       $("<li >", html: value).appendTo($outputList)
+
+      # You won't disable the submit button in this way.
+      # The responsible by disable it is Rails/Jquery UJS
+      # See: http://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-submit_tag
       $submit.removeProp("disabled")
       $input.val("")
 
   teardown: ->
-    super()
-    console.debug("HomeShowView.teardown()")
+    # https://github.com/turbolinks/turbolinks#building-your-turbolinks-application
+    # The documentation warns: In particular, you can no longer depend on a full page load to reset your environment every time you navigate...
+    # So every time you attached an event you'll need to undo it!
+    @$form.off "submit"
+    @logger.perform("  HomeShowView.teardown()")

--- a/app/assets/javascripts/views/statics/page_b.coffee
+++ b/app/assets/javascripts/views/statics/page_b.coffee
@@ -1,9 +1,6 @@
 class @StaticsPageBView extends Application.View
-
   setup: ->
-    super()
-    console.debug("StaticsPageBView.setup()")
+    @logger.perform("  StaticsPageBView.setup()")
 
   teardown: ->
-    super()
-    console.debug("StaticsPageBView.teardown()")
+    @logger.perform("  StaticsPageBView.teardown()")


### PR DESCRIPTION
Hello Gavin, how are you?

I saw your question in https://sevos.io/2017/02/27/turbolinks-lifecycle-explained.html comments, and I decided help you contributing with your code.

There was two things that could creating the duplicated log output.
1. Calls the super method inside of the StaticsPageBView and HomeShowView setup, teardown methods.
2. The logs created by the Turbolinks' cache steps.

So, I hope this contribution helps you with your question.
Bye!